### PR TITLE
Fixes: #1 make forgotpassword, register, login page device firendly

### DIFF
--- a/apps/bank-app/app/(auth)/forgotpassword/page.tsx
+++ b/apps/bank-app/app/(auth)/forgotpassword/page.tsx
@@ -5,7 +5,7 @@ import { Landmark } from "lucide-react";
 
 export default function ForgotPasswordPage() {
   return (
-    <div className="flex items-center justify-center w-full h-screen relative">
+    <div className="flex items-center p-6 sm:p-0 justify-center w-full h-screen relative">
       <div className="absolute top-3 left-3">
         <MyLink className="" href="/">
           <Label className="cursor-pointer font-bold">

--- a/apps/bank-app/app/(auth)/login/page.tsx
+++ b/apps/bank-app/app/(auth)/login/page.tsx
@@ -6,7 +6,7 @@ import { Landmark } from "lucide-react";
 
 export default function LoginPage() {
   return (
-    <div className="flex items-center justify-center w-full h-screen relative">
+    <div className="flex items-center p-6 sm:p-0 justify-center w-full h-screen relative">
       <div className="absolute top-3 left-3">
         <MyLink className="" href="/">
           <Label className="cursor-pointer font-bold">

--- a/apps/bank-app/app/(auth)/register/page.tsx
+++ b/apps/bank-app/app/(auth)/register/page.tsx
@@ -5,7 +5,7 @@ import { Landmark } from "lucide-react";
 
 export default async function RegisterPage() {
   return (
-    <div className="flex items-center justify-center w-full h-screen relative">
+    <div className="flex items-center p-6 sm:p-0 justify-center w-full h-screen relative">
       <div className="absolute top-3 left-3">
         <MyLink className="" href="/">
           <Label className="cursor-pointer font-bold">

--- a/apps/bank-app/components/ForgotPasswordForm.tsx
+++ b/apps/bank-app/components/ForgotPasswordForm.tsx
@@ -45,7 +45,7 @@ export function ForgotPasswordForm() {
   }, [number]);
 
   return (
-    <div className="flex flex-col w-1/3 shadow-lg p-4">
+    <div className="flex flex-col w-full sm:w-2/3 md:w-1/2 lg:w-1/3 shadow-lg p-4">
       <TopInfoShower setHide={setHideTopInfo} hide={hideTopInfo}>
         <p className="font-bold text-white">
           I am Gareeb <span className="text-2xl">🤒</span>, can't send you otp.
@@ -63,7 +63,7 @@ export function ForgotPasswordForm() {
           type="number"
           onChange={(value) => setNumber(value)}
         />
-        <div className="flex gap-4">
+        <div className="w-full flex gap-6 flex-wrap sm:flex-nowrap justify-end sm:justify-between">
           <OtpBox setOtp={setOtp} />
           <LoaderButton
             onClick={async () => {
@@ -86,7 +86,7 @@ export function ForgotPasswordForm() {
             isDisabled={isVerifyBtnDisabled}
           />
         </div>
-        <div className="flex gap-4">
+        <div className="flex flex-col sm:flex-row sm:gap-4 gap-6">
           <PasswordInput
             placeholder="Enter Password"
             icon={<LockKeyhole color="red" size={18} />}

--- a/apps/bank-app/components/LoginForm.tsx
+++ b/apps/bank-app/components/LoginForm.tsx
@@ -23,7 +23,7 @@ export function LoginForm() {
   }, [number, password]);
 
   return (
-    <div className="flex flex-col w-1/3 shadow-lg p-4">
+    <div className="flex flex-col w-full sm:w-2/3 md:w-1/2 lg:w-1/3 shadow-lg p-4">
       <h1 className="font-sans text-3xl font-extrabold text-slate-800 text-center mb-8">
         Login to Sistya Bank
       </h1>

--- a/apps/bank-app/components/RegisterForm.tsx
+++ b/apps/bank-app/components/RegisterForm.tsx
@@ -28,6 +28,7 @@ export function RegisterForm() {
   const [hideTopInfo, setHideTopInfo] = useState<boolean>(true);
   const [receivedOtp, setReceivedOtp] = useState<string | null | undefined>("");
   const router = useRouter();
+
   useEffect(() => {
     if (
       name &&
@@ -47,7 +48,7 @@ export function RegisterForm() {
   }, [number]);
 
   return (
-    <div className="flex flex-col w-1/3 shadow-lg p-4">
+    <div className="flex flex-col w-full sm:w-2/3 md:w-1/2 lg:w-1/3 shadow-lg p-4">
       <TopInfoShower setHide={setHideTopInfo} hide={hideTopInfo}>
         <p className="font-bold text-white">
           I am Gareeb <span className="text-2xl">🤒</span>, can't send you otp.
@@ -65,7 +66,7 @@ export function RegisterForm() {
           type="number"
           onChange={(value) => setNumber(value)}
         />
-        <div className="flex gap-4">
+        <div className="w-full flex gap-6 flex-wrap sm:flex-nowrap justify-end sm:justify-between">
           <OtpBox setOtp={setOtp} />
           <LoaderButton
             onClick={async () => {
@@ -94,7 +95,7 @@ export function RegisterForm() {
           type="text"
           onChange={(value) => setName(value)}
         />
-        <div className="flex gap-4">
+        <div className="flex flex-col sm:flex-row sm:gap-4 gap-6">
           <PasswordInput
             placeholder="Enter Password"
             icon={<LockKeyhole color="red" size={18} />}

--- a/apps/bank-app/components/custom/OtpBox.tsx
+++ b/apps/bank-app/components/custom/OtpBox.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  InputOTP,
-  InputOTPGroup,
-  InputOTPSeparator,
-  InputOTPSlot,
-} from "../ui/input-otp";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "../ui/input-otp";
 
 export function OtpBox({ setOtp }: { setOtp: (value: string) => void }) {
   return (
@@ -14,17 +9,17 @@ export function OtpBox({ setOtp }: { setOtp: (value: string) => void }) {
         setOtp(value);
       }}
       maxLength={6}
+      className="w-full"
     >
-      <InputOTPGroup className="gap-7.5">
-        <InputOTPSlot index={0} />
-        <InputOTPSlot index={1} />
-        <InputOTPSlot index={2} />
-      </InputOTPGroup>
-      <InputOTPSeparator />
-      <InputOTPGroup className="gap-7.5">
-        <InputOTPSlot index={3} />
-        <InputOTPSlot index={4} />
-        <InputOTPSlot index={5} />
+      <InputOTPGroup className="w-full">
+        <div className="flex w-full justify-between">
+          <InputOTPSlot index={0} />
+          <InputOTPSlot index={1} />
+          <InputOTPSlot index={2} />
+          <InputOTPSlot index={3} />
+          <InputOTPSlot index={4} />
+          <InputOTPSlot index={5} />
+        </div>
       </InputOTPGroup>
     </InputOTP>
   );

--- a/apps/bank-app/components/custom/TopInfoShower.tsx
+++ b/apps/bank-app/components/custom/TopInfoShower.tsx
@@ -9,12 +9,12 @@ export function TopInfoShower({ children, hide, setHide }: TopInfoShowerProps) {
   if (hide) return null;
   return (
     <div
-      className={`w-full bg-red-700 text-white h-12 absolute top-0 left-0 right-0`}
+      className={`w-full bg-red-700 text-white p-4 absolute top-0 left-0 right-0`}
     >
-      <div className="w-full h-full relative flex items-center justify-center">
+      <div className="w-full h-full flex text-center items-center justify-center">
         {children}
         <button
-          className="cursor-pointer absolute top-1 right-2"
+          className="cursor-pointer absolute top-1 right-1"
           onClick={() => {
             setHide(true);
           }}

--- a/apps/bank-app/components/ui/input-otp.tsx
+++ b/apps/bank-app/components/ui/input-otp.tsx
@@ -17,7 +17,7 @@ function InputOTP({
     <OTPInput
       data-slot="input-otp"
       containerClassName={cn(
-        "flex items-center gap-2 has-disabled:opacity-50",
+        "flex items-center gap-2 has-disabled:opacity-50 w-full",
         containerClassName,
       )}
       className={cn("disabled:cursor-not-allowed", className)}


### PR DESCRIPTION
This pull request fixes #3 the forgotpassword, login and register pages  ui mobile  responsive

![forgotpassword-page](https://github.com/user-attachments/assets/6287ce0b-135e-4c5d-b773-0639bc2083eb)
![login-page](https://github.com/user-attachments/assets/23319850-6554-4493-92bd-1b4a29b09e5c)
![create-account](https://github.com/user-attachments/assets/a064570a-7cbd-4ce6-ad3b-b9c6b9505fdd)
